### PR TITLE
feat(core): Add `(De)serialize` impl for `isize`/`usize` non-zero types.

### DIFF
--- a/xmlity/src/types/primitive.rs
+++ b/xmlity/src/types/primitive.rs
@@ -110,7 +110,9 @@ impl_serialize_for_nonzero_primitive!(
     core::num::NonZeroI16,
     core::num::NonZeroI32,
     core::num::NonZeroI64,
-    core::num::NonZeroI128
+    core::num::NonZeroI128,
+    core::num::NonZeroUsize,
+    core::num::NonZeroIsize
 );
 
 macro_rules! impl_deserialize_for_nonzero_primitive {
@@ -136,7 +138,9 @@ impl_deserialize_for_nonzero_primitive!(
     core::num::NonZeroI16,
     core::num::NonZeroI32,
     core::num::NonZeroI64,
-    core::num::NonZeroI128
+    core::num::NonZeroI128,
+    core::num::NonZeroUsize,
+    core::num::NonZeroIsize
 );
 
 #[cfg(test)]


### PR DESCRIPTION
I missed this in the previous PR #111 .