### PR TITLE
fix(core)!: Change `SerializeSeq` trait to return `()` for each individual element.

### DIFF
--- a/xmlity-quick-xml/src/ser.rs
+++ b/xmlity-quick-xml/src/ser.rs
@@ -385,7 +385,7 @@ impl<'a> ser::Serializer for &'a mut TextSerializer {
 
     type SerializeSeq = &'a mut TextSerializer;
 
-    fn serialize_text<S: AsRef<str>>(self, text: S) -> Result<Self::Ok, Self::Error> {
+    fn serialize_text<S: AsRef<str>>(self, text: S) -> Result<(), Self::Error> {
         if self.value.is_some() {
             return Err(Error::unexpected_serialize(Unexpected::Text));
         }
@@ -663,7 +663,7 @@ impl<W: Write> ser::SerializeSeq for ChildrenSerializeSeq<'_, W> {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_element<V: Serialize>(&mut self, value: &V) -> Result<Self::Ok, Self::Error> {
+    fn serialize_element<V: Serialize>(&mut self, value: &V) -> Result<(), Self::Error> {
         value.serialize(self.serializer.deref_mut())
     }
 
@@ -701,7 +701,7 @@ impl<W: Write> ser::SerializeSeq for SerializeSeq<'_, W> {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_element<V: Serialize>(&mut self, v: &V) -> Result<Self::Ok, Self::Error> {
+    fn serialize_element<V: Serialize>(&mut self, v: &V) -> Result<(), Self::Error> {
         v.serialize(self.serializer.deref_mut())
     }
 

--- a/xmlity/src/noop.rs
+++ b/xmlity/src/noop.rs
@@ -13,7 +13,7 @@ impl<Ok, Err: ser::Error> crate::ser::SerializeSeq for NoopDeSerializer<Ok, Err>
 
     type Error = Err;
 
-    fn serialize_element<V: ser::Serialize>(&mut self, _: &V) -> Result<Self::Ok, Self::Error> {
+    fn serialize_element<V: ser::Serialize>(&mut self, _: &V) -> Result<(), Self::Error> {
         unreachable!("Self has infallible child - cannot be constructed and thus cannot be used.")
     }
 

--- a/xmlity/src/ser.rs
+++ b/xmlity/src/ser.rs
@@ -133,7 +133,7 @@ pub trait SerializeSeq {
     type Error: Error;
 
     /// Serialize an element in the sequence.
-    fn serialize_element<V: Serialize>(&mut self, v: &V) -> Result<Self::Ok, Self::Error>;
+    fn serialize_element<V: Serialize>(&mut self, v: &V) -> Result<(), Self::Error>;
 
     /// End the serialization of the sequence.
     fn end(self) -> Result<Self::Ok, Self::Error>;

--- a/xmlity/src/value/serializer.rs
+++ b/xmlity/src/value/serializer.rs
@@ -338,7 +338,7 @@ impl crate::ser::SerializeSeq for &mut XmlSeq<XmlValue> {
 
     type Error = XmlValueSerializerError;
 
-    fn serialize_element<V: Serialize>(&mut self, v: &V) -> Result<Self::Ok, Self::Error> {
+    fn serialize_element<V: Serialize>(&mut self, v: &V) -> Result<(), Self::Error> {
         v.serialize(self)
     }
 
@@ -352,7 +352,7 @@ impl crate::ser::SerializeSeq for &mut XmlSeq<XmlChild> {
 
     type Error = XmlValueSerializerError;
 
-    fn serialize_element<V: Serialize>(&mut self, v: &V) -> Result<Self::Ok, Self::Error> {
+    fn serialize_element<V: Serialize>(&mut self, v: &V) -> Result<(), Self::Error> {
         v.serialize(self)?;
         Ok(())
     }


### PR DESCRIPTION
This should always have been the case and the fact that it wasn't was an oversight - as such I recognize it as a bug.