### PR TITLE
tests(derive): Adds test for `extendable = "iterator"`  option.

### DIFF
--- a/xmlity-quick-xml/tests/text/extendable.rs
+++ b/xmlity-quick-xml/tests/text/extendable.rs
@@ -18,7 +18,7 @@ define_test!(
 );
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct ExtendableVec(#[xvalue(extendable = true)] Vec<String>);
+pub struct ExtendableVec(#[xvalue(extendable = "iterator")] Vec<String>);
 
 define_test!(
     extendable_vec,

--- a/xmlity-quick-xml/tests/text/extendable.rs
+++ b/xmlity-quick-xml/tests/text/extendable.rs
@@ -6,7 +6,7 @@ use xmlity::{Deserialize, Serialize};
 pub struct ExtendableText(#[xvalue(extendable = true)] String);
 
 define_test!(
-    extendable_struct,
+    extendable_text,
     [
         (
             ExtendableText("BeforeInsideAfter".to_string()),
@@ -14,5 +14,24 @@ define_test!(
             "Before<![CDATA[Inside]]>After"
         ),
         (ExtendableText("Text".to_string()), "Text")
+    ]
+);
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExtendableVec(#[xvalue(extendable = true)] Vec<String>);
+
+define_test!(
+    extendable_vec,
+    [
+        (
+            ExtendableVec(vec![
+                "Before".to_string(),
+                "Inside".to_string(),
+                "After".to_string()
+            ]),
+            "BeforeInsideAfter",
+            "Before<![CDATA[Inside]]>After"
+        ),
+        (ExtendableVec(vec!["Text".to_string()]), "Text")
     ]
 );


### PR DESCRIPTION
~~When I wrote extendable, I somehow failed to create a test for `Vec<T>` and as such, I didn't capture the fact that the current implementation does not work for it, which makes the feature very limited.~~

I forgot I had already successfully implemented it. It was just missing tests.